### PR TITLE
Updates s6-overlay to v1.21.8.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -34,7 +34,7 @@ RUN \
     \
     && if [ "${BUILD_ARCH}" = "i386" ]; then S6_ARCH="x86"; else S6_ARCH="${BUILD_ARCH}"; fi \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v1.21.7.0/s6-overlay-${S6_ARCH}.tar.gz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-${S6_ARCH}.tar.gz" \
         | tar zxvf - -C / \
     \
     && mkdir -p /etc/fix-attrs.d \


### PR DESCRIPTION
# Proposed Changes

Updates to the latest release:

https://github.com/just-containers/s6-overlay/releases/tag/v1.21.8.0


<blockquote><img src="https://avatars0.githubusercontent.com/u/11309574?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/just-containers/s6-overlay">just-containers/s6-overlay</a></strong></div><div>s6 overlay for containers (includes execline, s6-linux-utils & a custom init) - just-containers/s6-overlay</div></blockquote>