### PR TITLE
:arrow_up: bump Ubuntu to focal-20200423

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ubuntu:bionic-20200403
+ARG BUILD_FROM=ubuntu:focal-20200423
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -24,10 +24,10 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        ca-certificates=20180409 \
-        curl=7.58.0-2ubuntu3.8 \
-        jq=1.5+dfsg-2 \
-        tzdata=2019c-0ubuntu0.18.04 \
+        ca-certificates=20190110ubuntu1 \
+        curl=7.68.0-1ubuntu2 \
+        jq=1.6-1 \
+        tzdata=2019c-3ubuntu1 \
     \
     && S6_ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "i386" ]; then S6_ARCH="x86"; fi \

--- a/base/build.json
+++ b/base/build.json
@@ -2,10 +2,10 @@
   "image": "hassioaddons/ubuntu-base-{arch}",
   "squash": false,
   "build_from": {
-    "aarch64": "arm64v8/ubuntu:bionic-20200403",
-    "amd64": "ubuntu:bionic-20200403",
-    "armv7": "arm32v7/ubuntu:bionic-20200403",
-    "i386": "i386/ubuntu:bionic-20200403"
+    "aarch64": "arm64v8/ubuntu:focal-20200423",
+    "amd64": "ubuntu:focal-20200423",
+    "armv7": "arm32v7/ubuntu:focal-20200423",
+    "i386": "i386/ubuntu:focal-20200423"
   },
   "args": {}
 }


### PR DESCRIPTION
# Proposed Changes

Bump Ubuntu [20.04 LTS](https://wiki.ubuntu.com/Releases) - Focal Fossa.

This upgrade is required for Grafana 7.0.0, which needs `libc6` >= 2.28.

```bash
root@39cf88c54917:/# apt show libc6
Package: libc6
Version: 2.31-0ubuntu9
Status: install ok installed
```


## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/