### PR TITLE
Upgrade s6 overlay to v2.2.0.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -33,7 +33,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then S6_ARCH="x86"; fi \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.0/s6-overlay-${S6_ARCH}.tar.gz" \
+    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.1/s6-overlay-${S6_ARCH}.tar.gz" \
         | tar zxvf - -C / \
     \
     && mkdir -p /etc/fix-attrs.d \


### PR DESCRIPTION
# Proposed Changes

Release notes: <https://github.com/just-containers/s6-overlay/releases/tag/v2.2.0.1>
