### PR TITLE
Do not overwrite /bin symlink

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -33,8 +33,16 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then S6_ARCH="x86"; fi \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
     \
-    && curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${S6_ARCH}.tar.gz" \
-        | tar zxvf - -C / \
+    && curl -J -L -o /tmp/s6-overlay.tar.gz \
+        "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${S6_ARCH}.tar.gz" \
+    \
+    && tar zxvfh \
+        /tmp/s6-overlay.tar.gz \
+        -C /usr \
+    \
+    && tar zxvfh \
+        /tmp/s6-overlay.tar.gz \
+        -C /usr ./bin \
     \
     && mkdir -p /etc/fix-attrs.d \
     && mkdir -p /etc/services.d \


### PR DESCRIPTION
# Proposed Changes

Do not overwrite the `/bin` symlink with the S6 overlay.

fixes #94