### PR TITLE
Use Ubuntu codename as image source

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ubuntu:22.04
+ARG BUILD_FROM=ubuntu:jammy
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/base/build.yaml
+++ b/base/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: arm64v8/ubuntu:22.04
-  amd64: amd64/ubuntu:22.04
-  armv7: arm32v7/ubuntu:22.04
+  aarch64: arm64v8/ubuntu:jammy
+  amd64: amd64/ubuntu:jammy
+  armv7: arm32v7/ubuntu:jammy
 codenotary:
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

It looks like renovate handles that better.


