### PR TITLE
Fix Renovate version template for s6 overlay

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,8 @@
       ],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "loose",
-      "depNameTemplate": "just-containers/s6-overlay"
+      "depNameTemplate": "just-containers/s6-overlay",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["/Dockerfile$"],


### PR DESCRIPTION
# Proposed Changes

It currently adds an extra `v`
