### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Home Assistant Community Add-ons.
 While Home Assistant provides base images, the images provided by this
 repository contain some extras:
 
-- Based on Ubuntu Bionic (slim)
+- Based on the latest Ubuntu LTS
 - Adds [s6] as a process supervisor.
 - Adds `jq` & `curl`, since every add-on uses them.
 - Adds Docker [Label Schema][label-schema] support.


### PR DESCRIPTION
Removed obsolete Ubuntu version from README


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README to reflect the use of the latest Ubuntu LTS base image instead of a specific version (Bionic).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->