### PR TITLE
⬆️ Bump tzdata to 2025b-0ubuntu0.24.04.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,7 +35,7 @@ RUN \
         ca-certificates=20240203 \
         curl=8.5.0-2ubuntu10.6 \
         jq=1.7.1-3ubuntu0.24.04.1 \
-        tzdata=2025b-0ubuntu0.24.04 \
+        tzdata=2025b-0ubuntu0.24.04.1 \
         xz-utils=5.6.1+really5.4.5-1 \
     \
     && S6_ARCH="${BUILD_ARCH}" \


### PR DESCRIPTION
# Proposed Changes
Updates tzdata to a version that is not purged from package repository.

## Related Issues

Follow up from https://github.com/hassio-addons/addon-ubuntu-base/pull/169

@frenck 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base system to use a more specific version of the timezone data package for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->